### PR TITLE
Remove anonymous thumbnail creation from dropzone

### DIFF
--- a/src/tb/component/formbuilder/form/element/views/form.element.view.file.js
+++ b/src/tb/component/formbuilder/form/element/views/form.element.view.file.js
@@ -214,9 +214,9 @@ define(
 
                             dropzone.removeFile(file);
                             dropzone.options.addedfile.call(dropzone, fileBackup);
-                            dropzone.createThumbnailFromUrl(fileBackup, require('content.manager').defaultPicturePath + '?' + new Date().getTime(), null, "Anonymous");
+                            dropzone.createThumbnailFromUrl(fileBackup, require('content.manager').defaultPicturePath + '?' + new Date().getTime());
                         }
-                    }, "Anonymous");
+                    });
 
                     element.val(value.path);
                 }


### PR DESCRIPTION
The anonymous creation caused 401 forbidden access on secured instances.